### PR TITLE
fix: Resolve "headers already sent" error and ensure correct page str…

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -3,7 +3,7 @@
 <html lang="en"><head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>YouTube Video Downloader</title>
+<title><?php echo _t('site_title', 'YouTube Video Downloader'); ?></title>
 <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&amp;display=swap" rel="stylesheet"/>

--- a/index.php
+++ b/index.php
@@ -1,19 +1,3 @@
-<!DOCTYPE html>
-<html lang="en"><head>
-<meta charset="utf-8"/>
-<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>YouTube Video Downloader</title>
-<link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&amp;display=swap" rel="stylesheet"/>
-<link rel="stylesheet" href="assets/css/style.css"/>
-<style>
-        body {
-            font-family: 'Roboto', sans-serif;
-        }
-    </style>
-</head>
-<body class="bg-blue-50">
 <?php 
     ini_set('display_errors', 1);
     ini_set('display_startup_errors', 1);


### PR DESCRIPTION
…ucture

This commit fixes the "Warning: session_start(): Session cannot be started after headers have already been sent" error.

Key changes:

1.  **Modified `index.php`:**
    - Moved the initial PHP block (including `ini_set` directives and the `include("includes/header.php");` statement) to the very beginning of the file. This ensures that `session_start()` (called via `includes/language.php` which is included by `includes/header.php`) is executed before any HTML output from `index.php`.
    - Removed redundant HTML structural elements (`<!DOCTYPE html>`, `<head>`, opening `<body>` tag) from `index.php` as these are already generated by `includes/header.php`.

2.  **Modified `includes/header.php`:**
    - Updated the `<title>` tag to use the `_t()` translation function, making the page title dynamically translatable: `<title><?php echo _t('site_title', 'YouTube Video Downloader'); ?></title>`

These changes ensure correct PHP session initialization and proper HTML document structure.